### PR TITLE
Make 'R' work after winning

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -128,10 +128,8 @@ impl Game {
                 }
             }
 
-            KeyCode::Char('r')
-                if self.state == GameState::Playing || self.state == GameState::Lost =>
-            {
-                self.reset()
+            KeyCode::Char('r') if self.state != GameState::PreInit => {
+                self.reset();
             }
 
             _ => (),


### PR DESCRIPTION
When "winning" a game, the game prints `Hit R to restart!`, but hitting R does nothing. This PR fixes that.