### PR TITLE
Decrease the flag count when removing a flag

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -134,6 +134,7 @@ impl Board {
         match &self.data[index].state {
             CellState::Flagged => {
                 self.data[index].state = CellState::Hidden;
+                self.num_used_flags -= 1;
                 if self.mines_locs.contains(&index) {
                     self.mines_flagged -= 1;
                 }


### PR DESCRIPTION
As of `main`, `num_used_flags` does not decrease when the user removes a flag. This PR tries to fix that.